### PR TITLE
Fixed case where dispatch_resume is called twice

### DIFF
--- a/IPDFCameraViewController/IPDFCameraViewController.m
+++ b/IPDFCameraViewController/IPDFCameraViewController.m
@@ -468,11 +468,7 @@
 
         [UIImageJPEGRepresentation(image, 1.0) writeToFile:filePath atomically:YES];
 
-        dispatch_async(dispatch_get_main_queue(), ^
-                       {
-                           completionHandler(filePath);
-                           dispatch_resume(_captureQueue);
-                       });
+        completionHandler(filePath);
     }];
 
 }


### PR DESCRIPTION
captureImageWithCompletionHander was calling into captureAsUIImageWithCompletionHander which was already calling dispatch_resume
